### PR TITLE
Missing CI env variable in build action

### DIFF
--- a/.github/workflows/production-deployment.yml
+++ b/.github/workflows/production-deployment.yml
@@ -33,6 +33,7 @@ jobs:
           REACT_APP_FIRE_BASE_MEASURMENT_ID: ${{ secrets.FIRE_BASE_MEASURMENT_ID_STAGING }}
           REACT_APP_CLOUD_FUNCTIONS_REST_API: ${{ secrets.CLOUD_FUNCTIONS_REST_API_STAGING }}
           REACT_APP_LOGIN_PAGE_URL: ${{ secrets.LOGIN_PAGE_URL_STAGING }}
+          CI: ''
       - name: Firebase deployment
         run: |
           npm install -g firebase-tools

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -25,6 +25,8 @@ jobs:
         run: npm ci
       - name: Building project
         run: npm run build
+        env:
+          CI: ''
   tests:
     name: Testing
 

--- a/.github/workflows/staging-deployment.yml
+++ b/.github/workflows/staging-deployment.yml
@@ -33,6 +33,7 @@ jobs:
           REACT_APP_FIRE_BASE_MEASURMENT_ID: ${{ secrets.FIRE_BASE_MEASURMENT_ID_STAGING }}
           REACT_APP_CLOUD_FUNCTIONS_REST_API: ${{ secrets.CLOUD_FUNCTIONS_REST_API_STAGING }}
           REACT_APP_LOGIN_PAGE_URL: ${{ secrets.LOGIN_PAGE_URL_STAGING }}
+          CI: ''
       - name: Firebase deployment
         run: |
           npm install -g firebase-tools


### PR DESCRIPTION
Details:
The build stage of the deployment was failing because of npm treating warning as errors. 

Screenshot:
<img width="514" alt="Screen Shot 2020-04-20 at 18 22 27" src="https://user-images.githubusercontent.com/9438362/79801124-e8c4be00-8333-11ea-9d5c-78b436b58235.png">

More details on this: [url](https://github.community/t5/GitHub-Actions/Treating-warnings-as-errors-because-process-env-CI-true/td-p/52593)
