### PR TITLE
Solved profile editing issue

### DIFF
--- a/src/state/actions/users.js
+++ b/src/state/actions/users.js
@@ -228,9 +228,12 @@ export const modifyUser = ({
   return async (dispatch, getState) => {
     dispatch(USERS_MODIFY_USER_INIT());
     const { locale } = getState().preferences;
-    const { logoUrl } = getState()
-      .users.data.filter(user => user.id === id)
-      .pop();
+    const { logoUrl } = isProfile
+      ? getState().auth.userData
+      : getState()
+          .users.data.filter(user => user.id === id)
+          .pop();
+
     let deleteLogoTask;
     let uploadLogoTask;
     let newLogoUrl = null;


### PR DESCRIPTION
Details: 
Solved issue for users editing their own profile. 

Issue: 
Users could not edit their profile due to logoUrl being brought from the users state from the Redux store.

Fix: 
Condition to take the logoUrl from the auth state when the user is editing it´s own profile.