### PR TITLE
Bugfix: Searchbar issue

### DIFF
--- a/src/pages/Users/index.jsx
+++ b/src/pages/Users/index.jsx
@@ -30,7 +30,7 @@ const Users = () => {
 
   const dispatch = useDispatch();
 
-  const [search, setSearch] = useState();
+  const [search, setSearch] = useState('');
 
   useEffect(() => {
     if (isAdmin) {


### PR DESCRIPTION
Issue:

- As the initial state was not set to undefined, the console was showing a warning because the input was changing from an uncontrolled state to a controlled state. 

Details:

- Changed `search` initial state to an empty string 