### PR TITLE
Fix script "setup-admin-dashboard"

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "test": "react-scripts test",
     "eject": "react-scripts eject",
     "lint": "eslint .",
-    "setup-admin-dashboard": "npm install && npm build && firebase deploy",
+    "setup-admin-dashboard": "npm install && npm run build && firebase deploy",
     "deploy": "npm run build && firebase deploy --only hosting",
     "precommit:react": "npm test",
     "precommit:functions": "cd functions/ && npm run build && npm test",


### PR DESCRIPTION
Fix the "setup-admin-dashboard" script where "npm build" is not working. Replace this with "npm run build"